### PR TITLE
Automatic update of dependency toml from 0.10.0 to 0.10.1

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -608,7 +608,7 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "index": "pypi",
-            "version": "==0.10.0"
+            "version": "==0.10.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -1034,7 +1034,7 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "index": "pypi",
-            "version": "==0.10.0"
+            "version": "==0.10.1"
         },
         "typed-ast": {
             "hashes": [


### PR DESCRIPTION
Dependency toml was used in version 0.10.0, but the current latest version is 0.10.1.