### PR TITLE
Automatic update of dependency pyyaml from 3.13 to 5.3.1

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -459,7 +459,7 @@
                 "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
             "index": "pypi",
-            "version": "==3.13"
+            "version": "==5.3.1"
         },
         "requests": {
             "hashes": [
@@ -999,7 +999,7 @@
                 "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
             "index": "pypi",
-            "version": "==3.13"
+            "version": "==5.3.1"
         },
         "requests": {
             "hashes": [


### PR DESCRIPTION
Dependency pyyaml was used in version 3.13, but the current latest version is 5.3.1.