### PR TITLE
Automatic update of dependency semver from 2.10.0 to 2.10.1

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -536,7 +536,7 @@
                 "sha256:a0fd30b371474a6ffcbb106074187bdacb4e17fbdd80abc9dffebccc420993a2"
             ],
             "index": "pypi",
-            "version": "==2.10.0"
+            "version": "==2.10.1"
         },
         "sentry-sdk": {
             "hashes": [


### PR DESCRIPTION
Dependency semver was used in version 2.10.0, but the current latest version is 2.10.1.