### PR TITLE
Automatic update of dependency pytest from 5.4.2 to 5.4.3

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -962,11 +962,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
-                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
+                "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1",
+                "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"
             ],
             "index": "pypi",
-            "version": "==5.4.2"
+            "version": "==5.4.3"
         },
         "pytest-cov": {
             "hashes": [


### PR DESCRIPTION
Dependency pytest was used in version 5.4.2, but the current latest version is 5.4.3.