### PR TITLE
Automatic update of dependency pytest-cov from 2.8.1 to 2.9.0

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -970,11 +970,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
-                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+                "sha256:b6a814b8ed6247bd81ff47f038511b57fe1ce7f4cc25b9106f1a4b106f1d9322",
+                "sha256:c87dfd8465d865655a8213859f1b4749b43448b5fae465cb981e16d52a811424"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==2.9.0"
         },
         "pytest-timeout": {
             "hashes": [


### PR DESCRIPTION
Dependency pytest-cov was used in version 2.8.1, but the current latest version is 2.9.0.