### PR TITLE
Release of version 0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,3 +213,7 @@ all the things that you see...
 * Update __init__.py
 * :pushpin: Automatic update of dependency semver from 2.10.0 to 2.10.1
 * :pushpin: Automatic update of dependency pyyaml from 3.13 to 5.3.1
+
+## Release 0.4.8 (2020-06-10T18:06:27)
+* :pushpin: Automatic update of dependency pytest-cov from 2.8.1 to 2.9.0
+* :pushpin: Automatic update of dependency pytest from 5.4.2 to 5.4.3

--- a/srcopsmetrics/__init__.py
+++ b/srcopsmetrics/__init__.py
@@ -1,4 +1,4 @@
 """A collection of tools to gather and analyze knowledge from projects' repositories."""
 
 __title__ = "src-ops-metrics"
-__version__ = "0.4.7"
+__version__ = "0.4.8"


### PR DESCRIPTION
Related: #116

Changelog:
* :pushpin: Automatic update of dependency pytest-cov from 2.8.1 to 2.9.0
* :pushpin: Automatic update of dependency pytest from 5.4.2 to 5.4.3